### PR TITLE
Add chip, bag and cauldron data structures

### DIFF
--- a/quacker/__init__.py
+++ b/quacker/__init__.py
@@ -1,0 +1,11 @@
+"""Core data structures for the Quacker simulator."""
+
+from .chip import Chip
+from .bag import Bag
+from .cauldron import Cauldron
+
+__all__ = [
+    "Chip",
+    "Bag",
+    "Cauldron",
+]

--- a/quacker/bag.py
+++ b/quacker/bag.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import random
+from typing import Dict, Iterable, List
+
+from .chip import Chip
+
+
+class Bag:
+    """A collection of ingredient chips that can be drawn at random."""
+
+    def __init__(self, contents: Dict[str, Iterable[int]]):
+        self._chips: List[Chip] = []
+        for color, values in contents.items():
+            for value in values:
+                self._chips.append(Chip(color=color, value=value))
+
+    def draw(self) -> Chip:
+        """Remove and return a random chip from the bag."""
+        if not self._chips:
+            raise ValueError("Cannot draw from an empty bag")
+        index = random.randrange(len(self._chips))
+        return self._chips.pop(index)
+
+    def __len__(self) -> int:
+        return len(self._chips)
+
+    def contents(self) -> List[Chip]:
+        """Return a copy of the current bag contents."""
+        return list(self._chips)

--- a/quacker/cauldron.py
+++ b/quacker/cauldron.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from .chip import Chip
+
+
+class Cauldron:
+    """Container for chips that have been drawn in the current round."""
+
+    def __init__(self, chips: Iterable[Chip] | None = None):
+        self._chips: List[Chip] = list(chips) if chips else []
+
+    def add(self, chip: Chip) -> None:
+        """Add a chip to the cauldron."""
+        self._chips.append(chip)
+
+    def last_chip(self) -> Optional[Chip]:
+        """Return the most recently added chip or ``None``."""
+        return self._chips[-1] if self._chips else None
+
+    def __len__(self) -> int:
+        return len(self._chips)
+
+    def total_value(self) -> int:
+        """Sum of all chip values currently in the cauldron."""
+        return sum(c.value for c in self._chips)
+
+    def chips(self) -> List[Chip]:
+        """Return a copy of chips currently in the cauldron."""
+        return list(self._chips)

--- a/quacker/chip.py
+++ b/quacker/chip.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Chip:
+    """Single chip drawn from a bag.
+
+    Attributes
+    ----------
+    color: str
+        The color of the chip, e.g. 'orange' or 'white'.
+    value: int
+        The numeric value printed on the chip.
+    """
+    color: str
+    value: int


### PR DESCRIPTION
## Summary
- implement `Chip` dataclass
- add `Bag` class for drawing chips
- add `Cauldron` class for tracking drawn chips
- expose these classes in `quacker` package

## Testing
- `python -m compileall -q quacker`
- `python - <<'EOF'
from quacker import Bag, Cauldron
bag = Bag({'white':[1,2], 'orange':[1]})
cauldron = Cauldron(); cauldron.add(bag.draw())
print('bag size', len(bag)); print('cauldron total', cauldron.total_value())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6854548da72c8332b8459beea530044e