### PR TITLE
Implement round simulation and strategies

### DIFF
--- a/quacker/__init__.py
+++ b/quacker/__init__.py
@@ -3,9 +3,21 @@
 from .chip import Chip
 from .bag import Bag
 from .cauldron import Cauldron
+from .simulator import (
+    simulate_round,
+    StopAt,
+    stop_before_big_white,
+    StopAtChance,
+    explosion_chance,
+)
 
 __all__ = [
     "Chip",
     "Bag",
     "Cauldron",
+    "simulate_round",
+    "StopAt",
+    "stop_before_big_white",
+    "StopAtChance",
+    "explosion_chance",
 ]

--- a/quacker/cauldron.py
+++ b/quacker/cauldron.py
@@ -26,6 +26,10 @@ class Cauldron:
         """Sum of all chip values currently in the cauldron."""
         return sum(c.value for c in self._chips)
 
+    def white_total(self) -> int:
+        """Sum of white chip values currently in the cauldron."""
+        return sum(c.value for c in self._chips if c.color == "white")
+
     def chips(self) -> List[Chip]:
         """Return a copy of chips currently in the cauldron."""
         return list(self._chips)

--- a/quacker/simulator.py
+++ b/quacker/simulator.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+from .bag import Bag
+from .cauldron import Cauldron
+
+# Type alias for a stop strategy function
+StopStrategy = Callable[[Bag, Cauldron], bool]
+
+EXPLOSION_THRESHOLD = 7
+
+
+def simulate_round(bag: Bag, strategy: StopStrategy) -> Tuple[Cauldron, bool]:
+    """Simulate drawing chips for a single round.
+
+    Parameters
+    ----------
+    bag:
+        The ``Bag`` to draw chips from. It will be modified by this function.
+    strategy:
+        A callable deciding whether to stop drawing. It is invoked after each
+        draw with the current state.
+
+    Returns
+    -------
+    cauldron: ``Cauldron`` containing all drawn chips.
+    exploded: ``bool`` indicating whether the cauldron exploded.
+    """
+    cauldron = Cauldron()
+    exploded = False
+
+    while len(bag) > 0:
+        chip = bag.draw()
+        cauldron.add(chip)
+        if chip.color == "white" and cauldron.white_total() > EXPLOSION_THRESHOLD:
+            exploded = True
+            break
+        if strategy(bag, cauldron):
+            break
+
+    return cauldron, exploded
+
+
+@dataclass
+class StopAt:
+    """Stop once the total value of white chips reaches ``threshold``."""
+
+    threshold: int = EXPLOSION_THRESHOLD
+
+    def __call__(self, bag: Bag, cauldron: Cauldron) -> bool:
+        return cauldron.white_total() >= self.threshold
+
+
+def stop_before_big_white(threshold: int = EXPLOSION_THRESHOLD) -> StopStrategy:
+    """Return a strategy that stops if any remaining white chip would explode."""
+
+    def strategy(bag: Bag, cauldron: Cauldron) -> bool:
+        current = cauldron.white_total()
+        for chip in bag.contents():
+            if chip.color == "white" and current + chip.value > threshold:
+                return True
+        return False
+
+    return strategy
+
+
+def explosion_chance(bag: Bag, cauldron: Cauldron, threshold: int = EXPLOSION_THRESHOLD) -> float:
+    """Probability that the next draw will cause an explosion."""
+    if len(bag) == 0:
+        return 0.0
+    current = cauldron.white_total()
+    risky = 0
+    for chip in bag.contents():
+        if chip.color == "white" and current + chip.value > threshold:
+            risky += 1
+    return risky / len(bag)
+
+
+@dataclass
+class StopAtChance:
+    """Stop once the explosion chance exceeds ``probability``."""
+
+    probability: float
+
+    def __call__(self, bag: Bag, cauldron: Cauldron) -> bool:
+        return explosion_chance(bag, cauldron) > self.probability
+


### PR DESCRIPTION
## Summary
- add white_total to Cauldron
- implement `simulate_round` and basic stop strategies
- expose simulator utilities in package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545ac011e48332ad1356b89b27959d