### PR TITLE
Implement scoring for quacker

### DIFF
--- a/quacker/__init__.py
+++ b/quacker/__init__.py
@@ -10,6 +10,12 @@ from .simulator import (
     StopAtChance,
     explosion_chance,
 )
+from .score import (
+    progress,
+    victory_points,
+    rubies,
+    score_cauldron,
+)
 
 __all__ = [
     "Chip",
@@ -20,4 +26,8 @@ __all__ = [
     "stop_before_big_white",
     "StopAtChance",
     "explosion_chance",
+    "progress",
+    "victory_points",
+    "rubies",
+    "score_cauldron",
 ]

--- a/quacker/cli.py
+++ b/quacker/cli.py
@@ -1,7 +1,15 @@
 import argparse
 import re
 
-from . import Bag, StopAt, stop_before_big_white, StopAtChance, simulate_round
+from . import (
+    Bag,
+    StopAt,
+    stop_before_big_white,
+    StopAtChance,
+    simulate_round,
+    score_cauldron,
+    progress,
+)
 
 
 def parse_bag(bag_desc: str) -> Bag:
@@ -65,9 +73,13 @@ def main(argv=None):
         raise ValueError('Unknown strategy')
 
     cauldron, exploded = simulate_round(bag, strategy)
+    vp, rubies = score_cauldron(cauldron)
     print("Drawn:", [(c.color, c.value) for c in cauldron.chips()])
+    print("Total value:", progress(cauldron))
     print("Total white:", cauldron.white_total())
     print("Exploded:", exploded)
+    print("Victory points:", vp)
+    print("Rubies:", rubies)
 
 
 if __name__ == '__main__':

--- a/quacker/score.py
+++ b/quacker/score.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from .cauldron import Cauldron
+
+# Progress thresholds for awarding victory points. Each tuple contains the
+# exclusive upper bound for progress and the points granted when progress is
+# below that bound.
+VP_TABLE: List[Tuple[int, int]] = [
+    (6, 0),
+    (10, 1),
+    (14, 2),
+    (18, 3),
+    (22, 4),
+    (26, 5),
+    (29, 6),
+    (32, 7),
+    (35, 8),
+    (38, 9),
+    (41, 10),
+    (44, 11),
+    (48, 12),
+    (51, 13),
+    (53, 14),
+    (float('inf'), 15),
+]
+
+# Progress spaces that award a ruby.
+RUBY_SPACES = {5, 9, 13, 16, 20, 24, 28, 30, 34, 36, 40, 42, 46, 50, 52}
+
+def progress(cauldron: Cauldron) -> int:
+    """Return the total value of all chips in ``cauldron``."""
+    return cauldron.total_value()
+
+def victory_points(p: int) -> int:
+    """Return the victory points for the given progress value."""
+    for threshold, vp in VP_TABLE:
+        if p < threshold:
+            return vp
+    # Fallback shouldn't be reached but return the final VP value
+    return VP_TABLE[-1][1]
+
+def rubies(p: int) -> int:
+    """Return the number of rubies for the given progress value."""
+    return 1 if p in RUBY_SPACES else 0
+
+def score_cauldron(cauldron: Cauldron) -> Tuple[int, int]:
+    """Calculate victory points and rubies earned from ``cauldron``."""
+    p = progress(cauldron)
+    return victory_points(p), rubies(p)


### PR DESCRIPTION
## Summary
- add a `score` module to calculate progress, victory points and rubies
- expose scoring helpers through the package API
- show scoring info in the CLI output

## Testing
- `python -m quacker.cli --bag "white1x3" --strategy stop_at --threshold 1`


------
https://chatgpt.com/codex/tasks/task_e_685479c2cedc8332ac3baeb222003abf